### PR TITLE
Require pycrypto >= 2.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=['gpsoauth'],
     include_package_data=True,
     install_requires=[
-        'pycrypto',
+        'pycrypto >= 2.5',
         'requests',
         'pyopenssl',
         'ndg-httpsclient',


### PR DESCRIPTION
gpsoauth imports Crypto.Cipher.PKCS1_OAEP which was new in pycrypto 2.5.

This should help tests which imports gpsoauth deep down in the stack when running on Travis CI. Travis still runs Ubuntu 12.04 which comes with python-crypto 2.4.1.